### PR TITLE
Documentation fix: Astring.String.head

### DIFF
--- a/src/astring.mli
+++ b/src/astring.mli
@@ -228,8 +228,8 @@ module String : sig
   (**/**)
 
   val head : ?rev:bool -> string -> char option
-  (** [head s] is [Some (get s h)] with [h = 0] if [rev = true] (default) or
-      [h = length s - 1] if [rev = false]. [None] is returned if [s] is
+  (** [head s] is [Some (get s h)] with [h = 0] if [rev = false] (default) or
+      [h = length s - 1] if [rev = true]. [None] is returned if [s] is
       empty. *)
 
   val get_head : ?rev:bool -> string -> char


### PR DESCRIPTION
The documentation for the argument `?rev` of `String.head` was inverted.
