### PR TITLE
Add conversions to/from stdlib sets and maps

### DIFF
--- a/src/astring.mli
+++ b/src/astring.mli
@@ -1024,6 +1024,12 @@ v} *)
     val of_list : string list -> set
     (** [of_list ss] is a set from the list [ss]. *)
 
+    val of_stdlib_set : Set.Make(String).t -> set
+    (** [of_stdlib_set s] is a set from the stdlib-compatible set [s]. *)
+
+    val to_stdlib_set : set -> Set.Make(String).t
+    (** [to_stdlib_set s] is the stdlib-compatible set equivalent to [s]. *)
+
     val pp : ?sep:(Format.formatter -> unit -> unit) ->
       (Format.formatter -> string -> unit) ->
         Format.formatter -> set -> unit
@@ -1085,6 +1091,12 @@ v} *)
     val of_list : (string * 'a) list -> 'a map
     (** [of_list bs] is [List.fold_left (fun m (k, v) -> add k v m) empty
         bs]. *)
+
+    val of_stdlib_map : 'a Map.Make(String).t -> 'a map
+    (** [of_stdlib_map m] is a map from the stdlib-compatible map [m]. *)
+
+    val to_stdlib_map : 'a map -> 'a Map.Make(String).t
+    (** [to_stdlib_map m] is the stdlib-compatible map equivalent to [m]. *)
 
     val pp : ?sep:(Format.formatter -> unit -> unit) ->
       (Format.formatter -> string * 'a -> unit) -> Format.formatter ->

--- a/src/astring_string.ml
+++ b/src/astring_string.ml
@@ -689,6 +689,9 @@ module Set = struct
   let find s ss = try Some (find s ss) with Not_found -> None
 
   let of_list = List.fold_left (fun acc s -> add s acc) empty
+
+  let of_stdlib_set s = s
+  let to_stdlib_set s = s
 end
 
 module Map = struct
@@ -712,6 +715,9 @@ module Map = struct
   let dom m = fold (fun k _ acc -> Set.add k acc) m Set.empty
 
   let of_list bs = List.fold_left (fun m (k,v) -> add k v m) empty bs
+
+  let of_stdlib_map m = m
+  let to_stdlib_map m = m
 
   let pp ?sep:(pp_sep = Format.pp_print_cut) pp_binding ppf (m : 'a t) =
     let pp_binding k v is_first =


### PR DESCRIPTION
An alternative to #10 which keeps the underlying set and map representation opaque.
