### PR TITLE
add times parameter to {String,Sub}.cuts

### DIFF
--- a/src/astring.mli
+++ b/src/astring.mli
@@ -362,7 +362,7 @@ module String : sig
 
       @raise Invalid_argument if [sep] is the empty string. *)
 
-  val cuts : ?rev:bool -> ?empty:bool -> sep:string -> string -> string list
+  val cuts : ?rev:bool -> ?empty:bool -> ?times:int -> sep:string -> string -> string list
   (** [cuts sep s] is the list of all substrings of [s] that are
       delimited by matches of the non empty separator string
       [sep]. Empty substrings are omitted in the list if [empty] is
@@ -374,7 +374,10 @@ module String : sig
       again, that is separator matches can't overlap. If there is no
       separator match in [s], the list [[s]] is returned.
 
-      The following invariants hold:
+      The string is cut by a maximum amount of [times] when [times > 0].
+      (Defaults to [0])
+
+      The following invariants hold, regardless of the value of [times]:
       {ul
       {- [concat ~sep (cuts ~empty:true ~sep s) = s]}
       {- [cuts ~empty:true ~sep s <> []]}}
@@ -652,7 +655,7 @@ v}
     val cut : ?rev:bool -> sep:sub -> sub -> (sub * sub) option
     (** [cut] is like {!String.cut}. [sep] can be on a different base string *)
 
-    val cuts : ?rev:bool -> ?empty:bool -> sep:sub -> sub -> sub list
+    val cuts : ?rev:bool -> ?empty:bool -> ?times:int -> sep:sub -> sub -> sub list
     (** [cuts] is like {!String.cuts}. [sep] can be on a different base
         string *)
 

--- a/test/test_string.ml
+++ b/test/test_string.ml
@@ -724,6 +724,158 @@ let cuts = test "String.cuts" @@ fun () ->
   eql (String.cuts ~rev ~empty:false ~sep:"aa" "aaaaa") ["a";];
   eql (String.cuts ~rev ~empty:true ~sep:"aa" "aaaaaa") [""; ""; ""; ""];
   eql (String.cuts ~rev ~empty:false ~sep:"aa" "aaaaaa") [];
+  let times = 1 in
+  eql (String.cuts ~times ~empty:true  ~sep:"," "") [""];
+  eql (String.cuts ~times ~empty:false ~sep:"," "") [];
+  eql (String.cuts ~times ~empty:true  ~sep:"," ",") [""; ""];
+  eql (String.cuts ~times ~empty:false ~sep:"," ",") [];
+  eql (String.cuts ~times ~empty:true  ~sep:"," ",,") [""; ","];
+  eql (String.cuts ~times ~empty:false ~sep:"," ",,") [","];
+  eql (String.cuts ~times ~empty:true  ~sep:"," ",,,") [""; ",,"];
+  eql (String.cuts ~times ~empty:false ~sep:"," ",,,") [",,"];
+  eql (String.cuts ~times ~empty:true  ~sep:"," "123") ["123"];
+  eql (String.cuts ~times ~empty:false ~sep:"," "123") ["123"];
+  eql (String.cuts ~times ~empty:true  ~sep:"," ",123") [""; "123"];
+  eql (String.cuts ~times ~empty:false ~sep:"," ",123") ["123"];
+  eql (String.cuts ~times ~empty:true  ~sep:"," "123,") ["123"; ""];
+  eql (String.cuts ~times ~empty:false ~sep:"," "123,") ["123"];
+  eql (String.cuts ~times ~empty:true  ~sep:"," "1,2,3") ["1"; "2,3"];
+  eql (String.cuts ~times ~empty:false ~sep:"," "1,2,3") ["1"; "2,3"];
+  eql (String.cuts ~times ~empty:true  ~sep:"," "1, 2, 3") ["1"; " 2, 3"];
+  eql (String.cuts ~times ~empty:false ~sep:"," "1, 2, 3") ["1"; " 2, 3"];
+  eql (String.cuts ~times ~empty:true  ~sep:"," ",1,2,,3,") [""; "1,2,,3,"];
+  eql (String.cuts ~times ~empty:false ~sep:"," ",1,2,,3,") ["1,2,,3,"];
+  eql (String.cuts ~times ~empty:true  ~sep:"," ", 1, 2,, 3,")
+    [""; " 1, 2,, 3,"];
+  eql (String.cuts ~times ~empty:false ~sep:"," ", 1, 2,, 3,") [" 1, 2,, 3,"];
+  eql (String.cuts ~times ~empty:true  ~sep:"<>" "") [""];
+  eql (String.cuts ~times ~empty:false ~sep:"<>" "") [];
+  eql (String.cuts ~times ~empty:true  ~sep:"<>" "<>") [""; ""];
+  eql (String.cuts ~times ~empty:false ~sep:"<>" "<>") [];
+  eql (String.cuts ~times ~empty:true  ~sep:"<>" "<><>") [""; "<>"];
+  eql (String.cuts ~times ~empty:false ~sep:"<>" "<><>") ["<>"];
+  eql (String.cuts ~times ~empty:true  ~sep:"<>" "<><><>") [""; "<><>"];
+  eql (String.cuts ~times ~empty:false ~sep:"<>" "<><><>") ["<><>"];
+  eql (String.cuts ~times ~empty:true  ~sep:"<>" "123") [ "123" ];
+  eql (String.cuts ~times ~empty:false ~sep:"<>" "123") [ "123" ];
+  eql (String.cuts ~times ~empty:true  ~sep:"<>" "<>123") [""; "123"];
+  eql (String.cuts ~times ~empty:false ~sep:"<>" "<>123") ["123"];
+  eql (String.cuts ~times ~empty:true  ~sep:"<>" "123<>") ["123"; ""];
+  eql (String.cuts ~times ~empty:false ~sep:"<>" "123<>") ["123"];
+  eql (String.cuts ~times ~empty:true  ~sep:"<>" "1<>2<>3") ["1"; "2<>3"];
+  eql (String.cuts ~times ~empty:false ~sep:"<>" "1<>2<>3") ["1"; "2<>3"];
+  eql (String.cuts ~times ~empty:true  ~sep:"<>" "1<> 2<> 3") ["1"; " 2<> 3"];
+  eql (String.cuts ~times ~empty:false ~sep:"<>" "1<> 2<> 3") ["1"; " 2<> 3"];
+  eql (String.cuts ~times ~empty:true  ~sep:"<>" "<>1<>2<><>3<>")
+    [""; "1<>2<><>3<>"];
+  eql (String.cuts ~times ~empty:false ~sep:"<>" "<>1<>2<><>3<>") ["1<>2<><>3<>";];
+  eql (String.cuts ~times ~empty:true  ~sep:"<>" "<> 1<> 2<><> 3<>")
+    [""; " 1<> 2<><> 3<>"];
+  eql (String.cuts ~times ~empty:false ~sep:"<>" "<> 1<> 2<><> 3<>")[" 1<> 2<><> 3<>"];
+  eql (String.cuts ~times ~empty:true  ~sep:"<>" ">>><>>>><>>>><>>>>")
+    [">>>"; ">>><>>>><>>>>" ];
+  eql (String.cuts ~times ~empty:false ~sep:"<>" ">>><>>>><>>>><>>>>")
+    [">>>"; ">>><>>>><>>>>" ];
+  eql (String.cuts ~times ~empty:true  ~sep:"<->" "<->>->") [""; ">->"];
+  eql (String.cuts ~times ~empty:false ~sep:"<->" "<->>->") [">->"];
+  eql (String.cuts ~times ~empty:true  ~sep:"aa" "aa") [""; ""];
+  eql (String.cuts ~times ~empty:false ~sep:"aa" "aa") [];
+  eql (String.cuts ~times ~empty:true  ~sep:"aa" "aaa") [""; "a"];
+  eql (String.cuts ~times ~empty:false ~sep:"aa" "aaa") ["a"];
+  eql (String.cuts ~times ~empty:true  ~sep:"aa" "aaaa") [""; "aa"];
+  eql (String.cuts ~times ~empty:false ~sep:"aa" "aaaa") ["aa"];
+  eql (String.cuts ~times ~empty:true  ~sep:"aa" "aaaaa") [""; "aaa"];
+  eql (String.cuts ~times ~empty:false ~sep:"aa" "aaaaa") ["aaa"];
+  eql (String.cuts ~times ~empty:true  ~sep:"aa" "aaaaaa") [""; "aaaa"];
+  eql (String.cuts ~times ~empty:false ~sep:"aa" "aaaaaa") ["aaaa"];
+
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"," "") [""];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"," "") [];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"," ",") [""; ""];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"," ",") [];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"," ",,") [","; ""];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"," ",,") [","];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"," ",,,") [",,"; ""];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"," ",,,") [",,"];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"," "123") ["123"];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"," "123") ["123"];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"," ",123") [""; "123"];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"," ",123") ["123"];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"," "123,") ["123"; ""];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"," "123,") ["123"];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"," "1,2,3") ["1,2"; "3"];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"," "1,2,3") ["1,2"; "3"];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"," "1, 2, 3") ["1, 2"; " 3"];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"," "1, 2, 3") ["1, 2"; " 3"];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"," ",1,2,,3,")
+    [",1,2,,3"; ""];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"," ",1,2,,3,") [",1,2,,3"];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"," ", 1, 2,, 3,")
+    [", 1, 2,, 3"; ""];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"," ", 1, 2,, 3,") [", 1, 2,, 3"];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"<>" "") [""];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"<>" "") [];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"<>" "<>") [""; ""];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"<>" "<>") [];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"<>" "<><>") ["<>"; ""];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"<>" "<><>") ["<>"];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"<>" "<><><>") ["<><>"; ""];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"<>" "<><><>") ["<><>"];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"<>" "123") [ "123" ];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"<>" "123") [ "123" ];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"<>" "<>123") [""; "123"];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"<>" "<>123") ["123"];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"<>" "123<>") ["123"; ""];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"<>" "123<>") ["123";];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"<>" "1<>2<>3") ["1<>2"; "3"];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"<>" "1<>2<>3") ["1<>2"; "3"];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"<>" "1<> 2<> 3") ["1<> 2"; " 3"];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"<>" "1<> 2<> 3") ["1<> 2"; " 3"];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"<>" "<>1<>2<><>3<>")
+    ["<>1<>2<><>3"; ""];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"<>" "<>1<>2<><>3<>")
+    ["<>1<>2<><>3"];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"<>" "<> 1<> 2<><> 3<>")
+                                   ["<> 1<> 2<><> 3";""];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"<>" "<> 1<> 2<><> 3<>")
+                                   ["<> 1<> 2<><> 3";];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"<>" ">>><>>>><>>>><>>>>")
+                                   [">>><>>>><>>>>"; ">>>" ];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"<>" ">>><>>>><>>>><>>>>")
+                                   [">>><>>>><>>>>"; ">>>" ];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"<->" "<->>->") [""; ">->"];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"<->" "<->>->") [">->"];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"aa" "aa") [""; ""];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"aa" "aa") [];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"aa" "aaa") ["a"; ""];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"aa" "aaa") ["a"];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"aa" "aaaa") ["aa"; ""];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"aa" "aaaa") ["aa"];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"aa" "aaaaa") ["aaa"; "";];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"aa" "aaaaa") ["aaa"];
+  eql (String.cuts ~rev ~times ~empty:true ~sep:"aa" "aaaaaa") ["aaaa"; ""];
+  eql (String.cuts ~rev ~times ~empty:false ~sep:"aa" "aaaaaa") ["aaaa"];
+
+  eql (String.cuts ~times:0 ~empty:true  ~sep:"," ",,,") [""; ""; ""; ""];
+  eql (String.cuts ~times:1 ~empty:true  ~sep:"," ",,,") [""; ",,"];
+  eql (String.cuts ~times:2 ~empty:true  ~sep:"," ",,,") [""; ""; ","];
+  eql (String.cuts ~times:3 ~empty:true  ~sep:"," ",,,") [""; ""; ""; ""];
+  eql (String.cuts ~times:4 ~empty:true  ~sep:"," ",,,") [""; ""; ""; ""];
+  eql (String.cuts ~rev ~times:0 ~empty:true  ~sep:"," ",,,") [""; ""; ""; ""];
+  eql (String.cuts ~rev ~times:1 ~empty:true  ~sep:"," ",,,") [",,"; ""];
+  eql (String.cuts ~rev ~times:2 ~empty:true  ~sep:"," ",,,") [","; ""; ""];
+  eql (String.cuts ~rev ~times:3 ~empty:true  ~sep:"," ",,,") [""; ""; ""; ""];
+  eql (String.cuts ~rev ~times:4 ~empty:true  ~sep:"," ",,,") [""; ""; ""; ""];
+  eql (String.cuts ~times:0 ~empty:false  ~sep:"," ",,,") [];
+  eql (String.cuts ~times:1 ~empty:false  ~sep:"," ",,,") [",,"];
+  eql (String.cuts ~times:2 ~empty:false  ~sep:"," ",,,") [","];
+  eql (String.cuts ~times:3 ~empty:false  ~sep:"," ",,,") [];
+  eql (String.cuts ~times:4 ~empty:false  ~sep:"," ",,,") [];
+  eql (String.cuts ~rev ~times:0 ~empty:false  ~sep:"," ",,,") [];
+  eql (String.cuts ~rev ~times:1 ~empty:false  ~sep:"," ",,,") [",,"];
+  eql (String.cuts ~rev ~times:2 ~empty:false  ~sep:"," ",,,") [","];
+  eql (String.cuts ~rev ~times:3 ~empty:false  ~sep:"," ",,,") [];
+  eql (String.cuts ~rev ~times:4 ~empty:false  ~sep:"," ",,,") [];
   ()
 
 let fields = test "String.fields" @@ fun () ->

--- a/test/test_sub.ml
+++ b/test/test_sub.ml
@@ -858,8 +858,8 @@ let cuts = test "String.Sub.cuts" @@ fun () ->
   let s s =
     String.sub ~start:1 ~stop:(1 + (String.length s)) (strf "\x00%s\x00" s)
   in
-  let cuts ?rev ?empty ~sep str =
-    String.Sub.cuts ?rev ?empty ~sep:(s sep) (s str)
+  let cuts ?rev ?empty ?times ~sep str =
+    String.Sub.cuts ?rev ?empty ?times ~sep:(s sep) (s str)
   in
   app_invalid ~pp:ppl (cuts ~sep:"") "";
   app_invalid ~pp:ppl (cuts ~sep:"") "123";
@@ -995,6 +995,157 @@ let cuts = test "String.Sub.cuts" @@ fun () ->
   eql (cuts ~rev ~empty:false ~sep:"aa" "aaaaa") ["a";];
   eql (cuts ~rev ~empty:true ~sep:"aa" "aaaaaa") [""; ""; ""; ""];
   eql (cuts ~rev ~empty:false ~sep:"aa" "aaaaaa") [];
+  let times = 1 in
+  eql (cuts ~times ~empty:true  ~sep:"," "") [""];
+  eql (cuts ~times ~empty:false ~sep:"," "") [];
+  eql (cuts ~times ~empty:true  ~sep:"," ",") [""; ""];
+  eql (cuts ~times ~empty:false ~sep:"," ",") [];
+  eql (cuts ~times ~empty:true  ~sep:"," ",,") [""; ","];
+  eql (cuts ~times ~empty:false ~sep:"," ",,") [","];
+  eql (cuts ~times ~empty:true  ~sep:"," ",,,") [""; ",,"];
+  eql (cuts ~times ~empty:false ~sep:"," ",,,") [",,"];
+  eql (cuts ~times ~empty:true  ~sep:"," "123") ["123"];
+  eql (cuts ~times ~empty:false ~sep:"," "123") ["123"];
+  eql (cuts ~times ~empty:true  ~sep:"," ",123") [""; "123"];
+  eql (cuts ~times ~empty:false ~sep:"," ",123") ["123"];
+  eql (cuts ~times ~empty:true  ~sep:"," "123,") ["123"; ""];
+  eql (cuts ~times ~empty:false ~sep:"," "123,") ["123"];
+  eql (cuts ~times ~empty:true  ~sep:"," "1,2,3") ["1"; "2,3"];
+  eql (cuts ~times ~empty:false ~sep:"," "1,2,3") ["1"; "2,3"];
+  eql (cuts ~times ~empty:true  ~sep:"," "1, 2, 3") ["1"; " 2, 3"];
+  eql (cuts ~times ~empty:false ~sep:"," "1, 2, 3") ["1"; " 2, 3"];
+  eql (cuts ~times ~empty:true  ~sep:"," ",1,2,,3,") [""; "1,2,,3,"];
+  eql (cuts ~times ~empty:false ~sep:"," ",1,2,,3,") ["1,2,,3,"];
+  eql (cuts ~times ~empty:true  ~sep:"," ", 1, 2,, 3,")
+    [""; " 1, 2,, 3,"];
+  eql (cuts ~times ~empty:false ~sep:"," ", 1, 2,, 3,") [" 1, 2,, 3,"];
+  eql (cuts ~times ~empty:true  ~sep:"<>" "") [""];
+  eql (cuts ~times ~empty:false ~sep:"<>" "") [];
+  eql (cuts ~times ~empty:true  ~sep:"<>" "<>") [""; ""];
+  eql (cuts ~times ~empty:false ~sep:"<>" "<>") [];
+  eql (cuts ~times ~empty:true  ~sep:"<>" "<><>") [""; "<>"];
+  eql (cuts ~times ~empty:false ~sep:"<>" "<><>") ["<>"];
+  eql (cuts ~times ~empty:true  ~sep:"<>" "<><><>") [""; "<><>"];
+  eql (cuts ~times ~empty:false ~sep:"<>" "<><><>") ["<><>"];
+  eql (cuts ~times ~empty:true  ~sep:"<>" "123") [ "123" ];
+  eql (cuts ~times ~empty:false ~sep:"<>" "123") [ "123" ];
+  eql (cuts ~times ~empty:true  ~sep:"<>" "<>123") [""; "123"];
+  eql (cuts ~times ~empty:false ~sep:"<>" "<>123") ["123"];
+  eql (cuts ~times ~empty:true  ~sep:"<>" "123<>") ["123"; ""];
+  eql (cuts ~times ~empty:false ~sep:"<>" "123<>") ["123"];
+  eql (cuts ~times ~empty:true  ~sep:"<>" "1<>2<>3") ["1"; "2<>3"];
+  eql (cuts ~times ~empty:false ~sep:"<>" "1<>2<>3") ["1"; "2<>3"];
+  eql (cuts ~times ~empty:true  ~sep:"<>" "1<> 2<> 3") ["1"; " 2<> 3"];
+  eql (cuts ~times ~empty:false ~sep:"<>" "1<> 2<> 3") ["1"; " 2<> 3"];
+  eql (cuts ~times ~empty:true  ~sep:"<>" "<>1<>2<><>3<>")
+    [""; "1<>2<><>3<>"];
+  eql (cuts ~times ~empty:false ~sep:"<>" "<>1<>2<><>3<>") ["1<>2<><>3<>";];
+  eql (cuts ~times ~empty:true  ~sep:"<>" "<> 1<> 2<><> 3<>")
+    [""; " 1<> 2<><> 3<>"];
+  eql (cuts ~times ~empty:false ~sep:"<>" "<> 1<> 2<><> 3<>")[" 1<> 2<><> 3<>"];
+  eql (cuts ~times ~empty:true  ~sep:"<>" ">>><>>>><>>>><>>>>")
+    [">>>"; ">>><>>>><>>>>" ];
+  eql (cuts ~times ~empty:false ~sep:"<>" ">>><>>>><>>>><>>>>")
+    [">>>"; ">>><>>>><>>>>" ];
+  eql (cuts ~times ~empty:true  ~sep:"<->" "<->>->") [""; ">->"];
+  eql (cuts ~times ~empty:false ~sep:"<->" "<->>->") [">->"];
+  eql (cuts ~times ~empty:true  ~sep:"aa" "aa") [""; ""];
+  eql (cuts ~times ~empty:false ~sep:"aa" "aa") [];
+  eql (cuts ~times ~empty:true  ~sep:"aa" "aaa") [""; "a"];
+  eql (cuts ~times ~empty:false ~sep:"aa" "aaa") ["a"];
+  eql (cuts ~times ~empty:true  ~sep:"aa" "aaaa") [""; "aa"];
+  eql (cuts ~times ~empty:false ~sep:"aa" "aaaa") ["aa"];
+  eql (cuts ~times ~empty:true  ~sep:"aa" "aaaaa") [""; "aaa"];
+  eql (cuts ~times ~empty:false ~sep:"aa" "aaaaa") ["aaa"];
+  eql (cuts ~times ~empty:true  ~sep:"aa" "aaaaaa") [""; "aaaa"];
+  eql (cuts ~times ~empty:false ~sep:"aa" "aaaaaa") ["aaaa"];
+
+  eql (cuts ~rev ~times ~empty:true ~sep:"," "") [""];
+  eql (cuts ~rev ~times ~empty:false ~sep:"," "") [];
+  eql (cuts ~rev ~times ~empty:true ~sep:"," ",") [""; ""];
+  eql (cuts ~rev ~times ~empty:false ~sep:"," ",") [];
+  eql (cuts ~rev ~times ~empty:true ~sep:"," ",,") [","; ""];
+  eql (cuts ~rev ~times ~empty:false ~sep:"," ",,") [","];
+  eql (cuts ~rev ~times ~empty:true ~sep:"," ",,,") [",,"; ""];
+  eql (cuts ~rev ~times ~empty:false ~sep:"," ",,,") [",,"];
+  eql (cuts ~rev ~times ~empty:true ~sep:"," "123") ["123"];
+  eql (cuts ~rev ~times ~empty:false ~sep:"," "123") ["123"];
+  eql (cuts ~rev ~times ~empty:true ~sep:"," ",123") [""; "123"];
+  eql (cuts ~rev ~times ~empty:false ~sep:"," ",123") ["123"];
+  eql (cuts ~rev ~times ~empty:true ~sep:"," "123,") ["123"; ""];
+  eql (cuts ~rev ~times ~empty:false ~sep:"," "123,") ["123"];
+  eql (cuts ~rev ~times ~empty:true ~sep:"," "1,2,3") ["1,2"; "3"];
+  eql (cuts ~rev ~times ~empty:false ~sep:"," "1,2,3") ["1,2"; "3"];
+  eql (cuts ~rev ~times ~empty:true ~sep:"," "1, 2, 3") ["1, 2"; " 3"];
+  eql (cuts ~rev ~times ~empty:false ~sep:"," "1, 2, 3") ["1, 2"; " 3"];
+  eql (cuts ~rev ~times ~empty:true ~sep:"," ",1,2,,3,")
+    [",1,2,,3"; ""];
+  eql (cuts ~rev ~times ~empty:false ~sep:"," ",1,2,,3,") [",1,2,,3"];
+  eql (cuts ~rev ~times ~empty:true ~sep:"," ", 1, 2,, 3,")
+    [", 1, 2,, 3"; ""];
+  eql (cuts ~rev ~times ~empty:false ~sep:"," ", 1, 2,, 3,") [", 1, 2,, 3"];
+  eql (cuts ~rev ~times ~empty:true ~sep:"<>" "") [""];
+  eql (cuts ~rev ~times ~empty:false ~sep:"<>" "") [];
+  eql (cuts ~rev ~times ~empty:true ~sep:"<>" "<>") [""; ""];
+  eql (cuts ~rev ~times ~empty:false ~sep:"<>" "<>") [];
+  eql (cuts ~rev ~times ~empty:true ~sep:"<>" "<><>") ["<>"; ""];
+  eql (cuts ~rev ~times ~empty:false ~sep:"<>" "<><>") ["<>"];
+  eql (cuts ~rev ~times ~empty:true ~sep:"<>" "<><><>") ["<><>"; ""];
+  eql (cuts ~rev ~times ~empty:false ~sep:"<>" "<><><>") ["<><>"];
+  eql (cuts ~rev ~times ~empty:true ~sep:"<>" "123") [ "123" ];
+  eql (cuts ~rev ~times ~empty:false ~sep:"<>" "123") [ "123" ];
+  eql (cuts ~rev ~times ~empty:true ~sep:"<>" "<>123") [""; "123"];
+  eql (cuts ~rev ~times ~empty:false ~sep:"<>" "<>123") ["123"];
+  eql (cuts ~rev ~times ~empty:true ~sep:"<>" "123<>") ["123"; ""];
+  eql (cuts ~rev ~times ~empty:false ~sep:"<>" "123<>") ["123";];
+  eql (cuts ~rev ~times ~empty:true ~sep:"<>" "1<>2<>3") ["1<>2"; "3"];
+  eql (cuts ~rev ~times ~empty:false ~sep:"<>" "1<>2<>3") ["1<>2"; "3"];
+  eql (cuts ~rev ~times ~empty:true ~sep:"<>" "1<> 2<> 3") ["1<> 2"; " 3"];
+  eql (cuts ~rev ~times ~empty:false ~sep:"<>" "1<> 2<> 3") ["1<> 2"; " 3"];
+  eql (cuts ~rev ~times ~empty:true ~sep:"<>" "<>1<>2<><>3<>")
+    ["<>1<>2<><>3"; ""];
+  eql (cuts ~rev ~times ~empty:false ~sep:"<>" "<>1<>2<><>3<>")
+    ["<>1<>2<><>3"];
+  eql (cuts ~rev ~times ~empty:true ~sep:"<>" "<> 1<> 2<><> 3<>")
+                                   ["<> 1<> 2<><> 3";""];
+  eql (cuts ~rev ~times ~empty:false ~sep:"<>" "<> 1<> 2<><> 3<>")
+                                   ["<> 1<> 2<><> 3";];
+  eql (cuts ~rev ~times ~empty:true ~sep:"<>" ">>><>>>><>>>><>>>>")
+                                   [">>><>>>><>>>>"; ">>>" ];
+  eql (cuts ~rev ~times ~empty:false ~sep:"<>" ">>><>>>><>>>><>>>>")
+                                   [">>><>>>><>>>>"; ">>>" ];
+  eql (cuts ~rev ~times ~empty:true ~sep:"<->" "<->>->") [""; ">->"];
+  eql (cuts ~rev ~times ~empty:false ~sep:"<->" "<->>->") [">->"];
+  eql (cuts ~rev ~times ~empty:true ~sep:"aa" "aa") [""; ""];
+  eql (cuts ~rev ~times ~empty:false ~sep:"aa" "aa") [];
+  eql (cuts ~rev ~times ~empty:true ~sep:"aa" "aaa") ["a"; ""];
+  eql (cuts ~rev ~times ~empty:false ~sep:"aa" "aaa") ["a"];
+  eql (cuts ~rev ~times ~empty:true ~sep:"aa" "aaaa") ["aa"; ""];
+  eql (cuts ~rev ~times ~empty:false ~sep:"aa" "aaaa") ["aa"];
+  eql (cuts ~rev ~times ~empty:true ~sep:"aa" "aaaaa") ["aaa"; "";];
+  eql (cuts ~rev ~times ~empty:false ~sep:"aa" "aaaaa") ["aaa"];
+  eql (cuts ~rev ~times ~empty:true ~sep:"aa" "aaaaaa") ["aaaa"; ""];
+  eql (cuts ~rev ~times ~empty:false ~sep:"aa" "aaaaaa") ["aaaa"];
+
+  eql (cuts ~times:0 ~empty:true  ~sep:"," ",,,") [""; ""; ""; ""];
+  eql (cuts ~times:1 ~empty:true  ~sep:"," ",,,") [""; ",,"];
+  eql (cuts ~times:2 ~empty:true  ~sep:"," ",,,") [""; ""; ","];
+  eql (cuts ~times:3 ~empty:true  ~sep:"," ",,,") [""; ""; ""; ""];
+  eql (cuts ~times:4 ~empty:true  ~sep:"," ",,,") [""; ""; ""; ""];
+  eql (cuts ~rev ~times:0 ~empty:true  ~sep:"," ",,,") [""; ""; ""; ""];
+  eql (cuts ~rev ~times:1 ~empty:true  ~sep:"," ",,,") [",,"; ""];
+  eql (cuts ~rev ~times:2 ~empty:true  ~sep:"," ",,,") [","; ""; ""];
+  eql (cuts ~rev ~times:3 ~empty:true  ~sep:"," ",,,") [""; ""; ""; ""];
+  eql (cuts ~rev ~times:4 ~empty:true  ~sep:"," ",,,") [""; ""; ""; ""];
+  eql (cuts ~times:0 ~empty:false  ~sep:"," ",,,") [];
+  eql (cuts ~times:1 ~empty:false  ~sep:"," ",,,") [",,"];
+  eql (cuts ~times:2 ~empty:false  ~sep:"," ",,,") [","];
+  eql (cuts ~times:3 ~empty:false  ~sep:"," ",,,") [];
+  eql (cuts ~times:4 ~empty:false  ~sep:"," ",,,") [];
+  eql (cuts ~rev ~times:0 ~empty:false  ~sep:"," ",,,") [];
+  eql (cuts ~rev ~times:1 ~empty:false  ~sep:"," ",,,") [",,"];
+  eql (cuts ~rev ~times:2 ~empty:false  ~sep:"," ",,,") [","];
+  eql (cuts ~rev ~times:3 ~empty:false  ~sep:"," ",,,") [];
   ()
 
 let fields = test "String.Sub.fields" @@ fun () ->


### PR DESCRIPTION
This parameter is useful when splitting a string into a variable amount of fields (up to a maximum) and the last field may contain the separator.

I thought this would be rare and `cut` would do the job, but in some cases more than 2 fields are present or having a single field is a valid option and in addition to that the tail of the string is unnecessarily split and has to be concatenated again, which reduces the readability of the code.

Some examples:
https://github.com/xapi-project/tapctl/blob/6827cad4bebd3e2fbd289a469231bf7570f265d2/lib/tapctl.ml#L394
https://github.com/xapi-project/xen-api/blob/802b8be78eb4ff88ab34a654af6a0cc27a83da72/ocaml/xapi-aux/pool_role.ml#L54-L58
https://github.com/xapi-project/xen-api/blob/324bc6ee6664dd915c0bbe57185f1d6243d9ed7e/ocaml/xapi/xapi_event.ml#L57-L61

I tried to make it as ergonomic as possible, but the choice of ignoring values lower than 1 is a bit awkward, but so is exposing the option. I'm open to suggestions.